### PR TITLE
Allow caching stable Emacs folders to speed up CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,19 @@ language: ruby
 sudo: false
 rvm:
   - 2.3.0
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EMACS_VERSION=snapshot
 cache:
-  bundler
+  - bundler
+  - directories:
+      - "$HOME/emacs"
 env:
   matrix:
     - EMACS_VERSION=24.5
     - EMACS_VERSION=25.1-rc2
+    - EMACS_VERSION=25.1
     - EMACS_VERSION=snapshot
     - TEXINFO_VERSION=6.1
 before_install:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Add the following to your `.travis.yml`:
 ``` yaml
 language: emacs-lisp
 sudo: false
+cache:
+  - directories:
+      # Cache stable Emacs binaries (saves 1min per job)
+      - "$HOME/emacs/"
 # Allow Emacs snapshot builds to fail and don’t wait for these as they can take
 # a looooong time
 matrix:
@@ -25,7 +29,7 @@ matrix:
 env:
   - EMACS_VERSION=24.3
   - EMACS_VERSION=24.5
-  - EMACS_VERSION=25.1-rc2
+  - EMACS_VERSION=25.1
   - EMACS_VERSION=snapshot
 before_install:
   # Configure $PATH: Executables are installed to $HOME/bin
@@ -45,8 +49,8 @@ script:
   - cask exec ert-runner
 ```
 
-This setup builds and tests your Emacs Lisp project on Emacs 24.3, 24.5 and the
-current Emacs snapshot from Git.
+This setup builds and tests your Emacs Lisp project on Emacs 24.3, 24.5, 25.1
+and the current Emacs snapshot from Git.
 
 Reference
 ---------


### PR DESCRIPTION
Travis has the ability to cache folders between builds.  Since Emacs stable
releases do not change, and installing them takes around 1min, they are a good
candidate for caching.

This commit modifies the makefile to download stable Emacs versions under
$HOME/emacs, a folder that can then be cached in travis.yml.  Caching is opt-in,
and documented in the README.

We still run `make install` every build, since caching every folder that Emacs
installs to might cache other locally installed packages.

Emacs snapshot is not cached, since it will presumably change often.