### PR TITLE
Fetch GnuTLS over HTTPS instead of FTP

### DIFF
--- a/emacs-travis.mk
+++ b/emacs-travis.mk
@@ -111,7 +111,7 @@ else
 	@echo "Install GnuTLS 3"
 	@sudo apt-get -qq update
 	@sudo apt-get install -y build-essential nettle-dev libgmp-dev
-	@wget ftp://ftp.gnutls.org/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz
+	@wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz
 	@tar -xf gnutls-3.1.23.tar.xz
 	@cd gnutls-3.1.23 \
 	  && ./configure $(SILENT) \


### PR DESCRIPTION
I'm seeing many builds failing to download GnuTLS or just timing out at the download, e.g.:

https://travis-ci.org/Emacs-D-Mode-Maintainers/Emacs-D-Mode/jobs/582421656#L514-L554

Considering that the file is also available over HTTP, there doesn't seem to be much benefit in using FTP.

I'll switch my `.travis.yml` to use this version and see if the change helps.